### PR TITLE
Attempt first try at modeling domain with refined types

### DIFF
--- a/src/main/scala/ordertaking/domain/GizmoRefined.scala
+++ b/src/main/scala/ordertaking/domain/GizmoRefined.scala
@@ -1,0 +1,52 @@
+package ordertaking.domain
+
+import cats.data.ValidatedNel
+import cats.syntax.all.*
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.cats.*
+import io.github.iltotore.iron.constraint.all.*
+
+object GizmoRefined extends App {
+  // Refinement types
+  type StartsWithG = DescribedAs[StartWith["G"], "Should start with G"]
+  // Note, I had to prefix my regex with `.` to match any character, which I don't hugely like
+  type Match3Digits = DescribedAs[Match[".[0-9][0-9][0-9]"], "Should match 3 digits"]
+  // Combine refinements
+  type GizmoCode = DescribedAs[StartsWithG & Match3Digits, "Should be G followed by three digits"]
+  case class Gizmo(code: String :| GizmoCode)
+
+  // CATS
+  /** This is just one example of the cats typeclasses Iron supports
+    */
+  def createGizmoValidatedNel(code: String): ValidatedNel[String, Gizmo] =
+    code.refineValidatedNel[GizmoCode].map(t => Gizmo.apply(t))
+
+  println(createGizmoValidatedNel("G123"))  // Valid(Gizmo(G123)
+  println(createGizmoValidatedNel("123"))   // Invalid(NonEmptyList(Should be G followed by three digits))
+  println(createGizmoValidatedNel("G1234")) // Invalid(NonEmptyList(Should be G followed by three digits))
+
+  // Why doesn't this work as an alternative implementation:
+  //  for {
+  //    startsWithG <- code.refineValidatedNel[StartsWithG]
+  //    validCode   <- startsWithG.refineFurtherValidatedNel[Match3Digits]
+  //  } yield Gizmo(validCode)
+
+  // EITHER
+
+  /** Refines the input string step by step. This is an example of composing refined types together.
+    */
+  def createGizmoEither(code: String): Either[String, Gizmo] =
+    for {
+      startsWithG <- code.refineEither[StartsWithG]
+      validCode   <- startsWithG.refineFurtherEither[Match3Digits]
+    } yield Gizmo(validCode)
+
+  println(createGizmoEither("G123"))  // Right(Gizmo(G123))
+  println(createGizmoEither("123"))   // Left(Should start with G)
+  println(createGizmoEither("G1234")) // Left(Should match 3 digits)
+
+  /** Refining the input string in one go using the `GizmoCode` type
+    */
+  def createGizmo(code: String): Either[String, Gizmo] =
+    code.refineEither[GizmoCode].map(Gizmo.apply)
+}

--- a/src/main/scala/ordertaking/domain/Types.scala
+++ b/src/main/scala/ordertaking/domain/Types.scala
@@ -1,0 +1,79 @@
+package ordertaking.domain
+
+import io.github.iltotore.iron.*
+import ordertaking.domain.Address.{BillingAddress, ShippingAddress}
+
+/** A code to identify a Product the company sells. */
+enum ProductCode:
+  /** Widgets have a code in the pattern `W1234` */
+  case Widget(code: String :| WidgetCode)
+
+  /** Gizmos have a code in the pattern `G123` */
+  case Gizmo(code: String :| GizmoCode)
+
+enum OrderQuantity:
+  /** An order can have a quantity from 1 to 1000 units */
+  case UnitQuantity(q: Int :| RefineUnit)
+
+  /** An order can have a quantity from 0.05kg to 100.0kg */
+  case KilogramQuantity(q: Float :| RefineKg)
+
+type OrderId             = String
+type OrderLineId         = String
+type CustomerId          = String
+type Price               = String
+type BillingAmount       = String
+type OrderPlaced         = Boolean
+type BillableOrderPlaced = Boolean
+
+enum Address:
+  case ShippingAddress(
+      addressLine1: String,
+      addressLine2: Option[String],
+      city: String,
+      postcode: String,
+      country: String
+  )
+  case BillingAddress(
+      addressLine1: String,
+      addressLine2: Option[String],
+      city: String,
+      postcode: String,
+      country: String
+  )
+
+case class Order(
+    id: OrderId,
+    customerId: CustomerId,
+    shippingAddress: ShippingAddress,
+    billingAddress: BillingAddress,
+    orderLines: List[OrderLine],
+    amountToBill: BillingAmount
+)
+
+case class OrderLine(
+    id: OrderLineId,
+    orderId: OrderId,
+    productCode: ProductCode,
+    orderQuantity: OrderQuantity,
+    price: Price
+)
+
+case class CustomerInfo(id: CustomerId, billingAddress: BillingAddress)
+
+case class UnvalidatedOrder(orderId: OrderId, customerInfo: CustomerInfo, shippingAddress: ShippingAddress)
+
+case class PlaceOrderEvents(
+    acknowledgementSent: Boolean,
+    orderPlaced: OrderPlaced,
+    billableOrderPlaced: BillableOrderPlaced
+)
+
+case class ValidationError(fieldName: String, description: String)
+
+enum PlaceOrderError:
+  case ValidationErrors(errors: List[ValidationError])
+
+trait OrderTaking {
+  def placeOrder(order: UnvalidatedOrder): Either[PlaceOrderError, PlaceOrderEvents]
+}

--- a/src/main/scala/ordertaking/domain/package.scala
+++ b/src/main/scala/ordertaking/domain/package.scala
@@ -1,0 +1,19 @@
+package ordertaking
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.cats.*
+import io.github.iltotore.iron.constraint.all.*
+package object domain {
+  type StartsWithG  = DescribedAs[StartWith["G"], "Should start with G"]
+  type Match3Digits = DescribedAs[Match[".[0-9][0-9][0-9]"], "Should match 3 digits"]
+  type GizmoCode    = DescribedAs[StartsWithG & Match3Digits, "Should be G followed by 3 digits"]
+  type StartsWithW  = DescribedAs[StartWith["W"], "Should start with W"]
+  type Match4Digits = DescribedAs[Match[".[0-9][0-9][0-9][0-9]"], "Should match 4 digits"]
+  type WidgetCode   = DescribedAs[StartsWithW & Match4Digits, "Should be W followed by 4 digits"]
+  type MinimumUnit  = DescribedAs[Greater[0], "Should be greater than 0"]
+  type MaximumUnit  = DescribedAs[LessEqual[1000], "Should be less than or equal to 1000"]
+  type RefineUnit   = DescribedAs[MinimumUnit & MaximumUnit, "Unit should be 0 > Unit >= 1000"]
+  type MinimumKg    = DescribedAs[GreaterEqual[0.05], "Should be greater or equal to 0.5kg"]
+  type MaximumKg    = DescribedAs[LessEqual[100.0], "Should be less than or equal to 100.0kg"]
+  type RefineKg     = DescribedAs[MinimumKg & MaximumKg, "Kg should be 0.05 >= Kg >= 100.0"]
+}

--- a/src/test/scala/ordertaking/domain/RefinedTypesSpec.scala
+++ b/src/test/scala/ordertaking/domain/RefinedTypesSpec.scala
@@ -1,0 +1,49 @@
+package ordertaking.domain
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import ordertaking.domain._
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+
+class RefinedTypesSpec extends AnyFreeSpec with Matchers {
+  "ProductCode" - {
+    import ordertaking.domain.ProductCode._
+    "Gizmos" - {
+      "Correct code" in {
+        "val gizmo = Gizmo(\"G123\")" should compile
+      }
+      "Incorrect code" in {
+        "val gizmo = Gizmo(\"G1234\")" shouldNot compile
+      }
+    }
+    "Widgets" - {
+      "Correct code" in {
+        "val widget = Widget(\"W1234\")" should compile
+      }
+      "Incorrect code" in {
+        "val widget = Widget(\"A12345\")" shouldNot compile
+      }
+    }
+  }
+  "OrderQuantity" - {
+    import ordertaking.domain.OrderQuantity._
+    "Units" - {
+      "Correct quantity" in {
+        "val quantity = UnitQuantity(20)" should compile
+      }
+      "Incorrect quantity" in {
+        "val quantity = UnitQuantity(-20)" shouldNot compile
+      }
+    }
+    "Kilograms" - {
+      "Correct quantity" in {
+        "val quantity = KilogramQuantity(0.5f)" should compile
+      }
+      "Incorrect quantity" in {
+        "val quantity = KilogramQuantity(0.01f)" shouldNot compile
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
`Types` contains the first attempt at modelling the domain, along with using the refined types from the package object.

`GizmoRefined` is playing around with Iron a bit, trying to understand how it works. I played around with `Either` and cats `ValidatedNel`. 

Something I was trying to do was accumulate errors. For example, for a `Gizmo`, if you pass the code `W1234`, this would fail both on what it starts with and the number of digits, then I would expect the error message to tell me both refinements failed.

"RefinedTypesSpec" - I have no idea how the `should/shouldNot compile` assertion works, but I would like to.  I saw [this](https://stackoverflow.com/questions/15125457/testing-an-assertion-that-something-must-not-compile) on stack overflow but need to look into it more.